### PR TITLE
Fix broken links

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Félix López
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ I created this simulator to help me show how Gossip Protocols work in my talks, 
 
 When I started reading about Gossip I couldn't find a good introduction, there were thounsands of papers but I didn't a find a good and simple summary. So I created this one: In http://managementfromscratch.wordpress.com/2016/04/01/introduction-to-gossip/
 
-After that I gave a talk at https://paperswelove.org, that talk was complete theoretical and I realized it was toomuch info for one hour. That's why I came up with idea of a simulator to help understand how they work. 
+After that I gave a talk at https://paperswelove.org, which was complete theoretical and I realized it was too much info for one hour. That's why I came up with idea of a simulator to help understand how they work. 
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Gossip Simulator
 
-I created this simulator to help me show how Gossip Protocols work in my talks, for example:
- https://2016.codemotion.es/agenda.html#5732408326356992/84654005is
+I created this simulator to help me show how Gossip Protocols work in my talks, for example [this one](https://youtu.be/QQ2n1UX3Qwg).
 
-When I started reading about Gossip I couldn't find a good introduction, there were thounsands of papers but I didn't a find a good and simple summary. So I created this one: In managementfromscratch.wordpress.com/2016/04/01/introduction-to-gossip/
+When I started reading about Gossip I couldn't find a good introduction, there were thounsands of papers but I didn't a find a good and simple summary. So I created this one: In http://managementfromscratch.wordpress.com/2016/04/01/introduction-to-gossip/
 
-After that I gave a talk at @PapersWeLoveMad --> https://twitter.com/PapersWeLoveMad/status/771399064718045185 that talk was complete theoretical and I realized it was toomuch info for one hour. That's why I came up with idea of a simulator to help understand how they work. 
+After that I gave a talk at https://paperswelove.org, that talk was complete theoretical and I realized it was toomuch info for one hour. That's why I came up with idea of a simulator to help understand how they work. 
 
-##Usage
+## Usage
 
 Go to https://flopezluis.github.io/gossip-simulator/
 

--- a/index.html
+++ b/index.html
@@ -232,12 +232,12 @@ Gossip-Based Implementations</a>For me the best paper to understand Gossip and h
       <div class="row featurette">
         <div class="col-md-12">
           <h2 class="featurette-heading one-column">References</h2>
-          <p class="lead">[1] Ken Birman. The Promise, and Limitations, of Gossip Protocols. SIGOPS Oper. Syst. Rev., 41(5):8–13, October 2007 </p>
-          <p class="lead">[2] A. Demers, D. Greene, C. Hauser, W. Irish, J. Larson, S. Shenker, H. Sturgis, D. Swinehart, and D. Terry. “Epidemic Algorithms for Replicated Database Maintenance.” In Proc. Sixth Symp. on Principles of Distributed Computing, pp. 1–12, Aug. 1987. ACM.</p>
-          <p class="lead">[3] JELASITY, M., GUERRAOUI, R., KERMARREC, A.-M., AND VAN STEEN, M. 2004. The peer sampling service: Experimental evaluation of unstructured gossip-based implementations. In Middleware 2004, H.-A. Jacobsen, Ed. Lecture Notes in Computer Science, vol. 3231. Springer-Verlag, 79–98.</p>
-          <p class="lead">[4] http://www.inf.u-szeged.hu/~jelasity/ddm/gossip.pdf</p>
-          <p class="lead">[5] S. Voulgaris, M. Jelasity, M. van Steen, A Robust and Scalable Peer-to-Peer Gossiping Protocol,Lecture Notes in Computer Science (LNCS), vol. 2872 (Springer, Berlin/Heidelberg, 2004), pp. 47–58. doi:10.1007/b104265</p>
-          <p class="lead">[6] J. Leita ̃o, J. Pereira, and L. Rodrigues. Hyparview: a membership protocol for reliable gossip-based broadcast. In Proceedings of the Internacional Conference on Dependable Systems and Networks (DSN), Edinburgh, UK, June 2007.</p>
+          <p class="lead">[1] Ken Birman. <a href="https://doi.org/10.1145/1317379.1317382">The Promise, and Limitations, of Gossip Protocols</a>. SIGOPS Oper. Syst. Rev., 41(5):8–13, October 2007 </p>
+          <p class="lead">[2] A. Demers, D. Greene, C. Hauser, W. Irish, J. Larson, S. Shenker, H. Sturgis, D. Swinehart, and D. Terry. <a href="https://doi.org/10.1145/41840.41841">Epidemic Algorithms for Replicated Database Maintenance</a>. In Proc. Sixth Symp. on Principles of Distributed Computing, pp. 1–12, Aug. 1987. ACM.</p>
+          <p class="lead">[3] JELASITY, M., GUERRAOUI, R., KERMARREC, A.-M., AND VAN STEEN, M. 2004. <a href="https://doi.org/10.1007/978-3-540-30229-2_5">The peer sampling service: Experimental evaluation of unstructured gossip-based implementations</a>. In Middleware 2004, H.-A. Jacobsen, Ed. Lecture Notes in Computer Science, vol. 3231. Springer-Verlag, 79–98.</p>
+          <p class="lead">[4] <a href="http://www.inf.u-szeged.hu/~jelasity/ddm/gossip.pdf">Gossip Protocols</a></p>
+          <p class="lead">[5] S. Voulgaris, M. Jelasity, M. van Steen, <a href="https://doi.org/10.1007/978-3-540-25840-7_6">A Robust and Scalable Peer-to-Peer Gossiping Protocol</a>, Lecture Notes in Computer Science (LNCS), vol. 2872 (Springer, Berlin/Heidelberg, 2004), pp. 47–58.</p>
+          <p class="lead">[6] J. Leitão, J. Pereira, and L. Rodrigues. <a href="https://doi.org/10.1109/DSN.2007.56">Hyparview: a membership protocol for reliable gossip-based broadcast</a>. In Proceedings of the Internacional Conference on Dependable Systems and Networks (DSN), Edinburgh, UK, June 2007.</p>
         </div>
       </div>
       <hr class="featurette-divider">


### PR DESCRIPTION
Thanks for this nice graphical simulator.
This PR just fix the following issues in the README.md:

- Fix Broken links and replaces non-existing ones
- Fix typos
- Add MIT license file
- Add DOI links for papers